### PR TITLE
fix(ci): install pnpm before setup-node to enable pnpm cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -37,10 +37,14 @@ const { experience, education } = experienceData as {
             </span>
             <div class="flex flex-col md:flex-row md:justify-between md:items-baseline gap-2 mb-4">
               <h3 class="text-xl font-bold text-primary">{item.title}</h3>
-              <span class="badge badge-outline font-mono text-xs">{item.period}</span>
+              <span class="badge badge-outline font-mono text-xs">
+                {item.period}
+              </span>
             </div>
             <p class="text-lg font-semibold mb-2">{item.company}</p>
-            <p class="text-base-content/80 mb-4 max-w-2xl">{item.description}</p>
+            <p class="text-base-content/80 mb-4 max-w-2xl">
+              {item.description}
+            </p>
             {item.achievements && item.achievements.length > 0 && (
               <ul class="list-disc list-inside space-y-1 text-sm text-base-content/70">
                 {item.achievements.map((achievement) => (
@@ -66,7 +70,9 @@ const { experience, education } = experienceData as {
             <div class="card-body p-6">
               <div class="flex justify-between items-start gap-4 mb-2">
                 <h3 class="text-lg font-bold">{item.title}</h3>
-                <span class="text-xs font-mono opacity-60 shrink-0">{item.period}</span>
+                <span class="text-xs font-mono opacity-60 shrink-0">
+                  {item.period}
+                </span>
               </div>
               <p class="text-primary font-medium text-sm mb-2">{item.school}</p>
               <p class="text-sm text-base-content/70">{item.description}</p>

--- a/src/components/Experience.astro
+++ b/src/components/Experience.astro
@@ -1,0 +1,79 @@
+---
+import experienceData from "../config/experience.json";
+
+interface Experience {
+  title: string;
+  company: string;
+  period: string;
+  description: string;
+  achievements?: string[];
+}
+
+interface Education {
+  title: string;
+  school: string;
+  period: string;
+  description: string;
+}
+
+const { experience, education } = experienceData as {
+  experience: Experience[];
+  education: Education[];
+};
+---
+
+<section id="experiencia" class="py-12 space-y-12">
+  <div>
+    <h2 class="text-3xl font-bold mb-10 flex items-center gap-2">
+      <span class="text-primary">#</span> Experiencia Profesional
+    </h2>
+
+    <div class="relative border-s border-base-300 ml-4 space-y-12">
+      {
+        experience.map((item) => (
+          <div class="ms-8 relative">
+            <span class="absolute -start-[41px] flex items-center justify-center w-6 h-6 bg-primary rounded-full ring-8 ring-base-100">
+              <div class="size-2 bg-primary-content rounded-full" />
+            </span>
+            <div class="flex flex-col md:flex-row md:justify-between md:items-baseline gap-2 mb-4">
+              <h3 class="text-xl font-bold text-primary">{item.title}</h3>
+              <span class="badge badge-outline font-mono text-xs">{item.period}</span>
+            </div>
+            <p class="text-lg font-semibold mb-2">{item.company}</p>
+            <p class="text-base-content/80 mb-4 max-w-2xl">{item.description}</p>
+            {item.achievements && item.achievements.length > 0 && (
+              <ul class="list-disc list-inside space-y-1 text-sm text-base-content/70">
+                {item.achievements.map((achievement) => (
+                  <li>{achievement}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        ))
+      }
+    </div>
+  </div>
+
+  <div>
+    <h2 class="text-3xl font-bold mb-10 flex items-center gap-2 pt-8">
+      <span class="text-primary">#</span> Formación
+    </h2>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      {
+        education.map((item) => (
+          <div class="card bg-base-100 border border-base-200 hover:border-primary/20 transition-all duration-300">
+            <div class="card-body p-6">
+              <div class="flex justify-between items-start gap-4 mb-2">
+                <h3 class="text-lg font-bold">{item.title}</h3>
+                <span class="text-xs font-mono opacity-60 shrink-0">{item.period}</span>
+              </div>
+              <p class="text-primary font-medium text-sm mb-2">{item.school}</p>
+              <p class="text-sm text-base-content/70">{item.description}</p>
+            </div>
+          </div>
+        ))
+      }
+    </div>
+  </div>
+</section>

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -3,6 +3,7 @@ import { Icon } from "astro-icon/components";
 
 const navLinks = [
   { href: "#sobre-mi", label: "Sobre mí" },
+  { href: "#experiencia", label: "Experiencia" },
   { href: "#habilidades", label: "Habilidades" },
 ];
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,12 @@
 ---
 import Home from "@components/Home.astro";
+import Experience from "@components/Experience.astro";
 import Skills from "@components/Skills.astro";
 import Layout from "@layouts/Layout.astro";
 ---
 
 <Layout>
   <Home />
+  <Experience />
   <Skills />
 </Layout>


### PR DESCRIPTION
## Fix CI: pnpm installation order\n\nSe reordena el workflow de CI para que Version 9.3.0 (compiled to binary; bundled Node.js v18.5.0)
Usage: pnpm [command] [flags]
       pnpm [ -h | --help | -v | --version ]

Manage your dependencies:
      add                  Installs a package and any packages that it depends
                           on. By default, any new package is installed as a
                           prod dependency
      import               Generates a pnpm-lock.yaml from an npm
                           package-lock.json (or npm-shrinkwrap.json) file
   i, install              Install all dependencies for a project
  it, install-test         Runs a pnpm install followed immediately by a pnpm
                           test
  ln, link                 Connect the local project to another one
      prune                Removes extraneous packages
  rb, rebuild              Rebuild a package
  rm, remove               Removes packages from node_modules and from the
                           project's package.json
      unlink               Unlinks a package. Like yarn unlink but pnpm
                           re-installs the dependency after removing the
                           external link
  up, update               Updates packages to their latest version based on the
                           specified range

Review your dependencies:
      audit                Checks for known security issues with the installed
                           packages
      licenses             Check licenses in consumed packages
  ls, list                 Print all the versions of packages that are
                           installed, as well as their dependencies, in a
                           tree-structure
      outdated             Check for outdated packages

Run your scripts:
      exec                 Executes a shell command in scope of a project
      run                  Runs a defined package script
      start                Runs an arbitrary command specified in the package's
                           "start" property of its "scripts" object
   t, test                 Runs a package's "test" script, if one was provided

Other:
      cat-file             Prints the contents of a file based on the hash value
                           stored in the index file
      cat-index            Prints the index file of a specific package from the
                           store
      find-hash            Experimental! Lists the packages that include the
                           file with the specified hash.
      pack                 Create a tarball from a package
      publish              Publishes a package to the registry
      root                 Prints the effective modules directory

Manage your store:
      store add            Adds new packages to the pnpm store directly. Does
                           not modify any projects or files outside the store
      store path           Prints the path to the active store directory
      store prune          Removes unreferenced (extraneous, orphan) packages
                           from the store
      store status         Checks for modified packages in the store

Options:
  -r, --recursive          Run the command for each project in the workspace. se instale antes de . Esto evita el error donde  intenta configurar el cache para pnpm sin que pnpm esté disponible en el PATH.\n\nCambios:\n- Mover  antes de  en .\n\nEsto debería solucionar el fallo: .