### PR TITLE
chore(deploy): add vercel.json with security headers and asset cache

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,32 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' va.vercel-scripts.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' vitals.vercel-insights.com"
+        }
+      ]
+    },
+    {
+      "source": "/_astro/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #20

## Summary

- Create `vercel.json` with HTTP security headers applied to all routes
- Add long-lived cache for `/_astro/*` hashed static assets (CSS, JS, images)

## Changes

| File | Change |
|------|--------|
| `vercel.json` | New: security headers + cache rules |

## Headers added

| Header | Value |
|--------|-------|
| `X-Content-Type-Options` | `nosniff` |
| `X-Frame-Options` | `DENY` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
| `Content-Security-Policy` | self + unsafe-inline (DaisyUI) + va.vercel-scripts.com (SpeedInsights) |
| `Cache-Control` (/_astro/*) | `public, max-age=31536000, immutable` |

## Test Plan

- [x] `pnpm build` — complete
- [x] JSON valid (prettier passes)
- [ ] Deploy to production and verify headers via securityheaders.com