### PR TITLE
perf(images): migrate Projects to Astro Image component

### DIFF
--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -1,0 +1,78 @@
+---
+import { getCollection } from "astro:content";
+import { Image } from "astro:assets";
+
+const projects = await getCollection("projects");
+const visible = projects.filter((p) => !p.data.draft);
+---
+
+<section id="proyectos" class="py-12">
+  <h2 class="text-3xl font-bold mb-8 flex items-center gap-2">
+    <span class="text-primary">#</span> Proyectos
+  </h2>
+
+  {
+    visible.length === 0 ? (
+      <p class="text-base-content/70">
+        No hay proyectos publicados por el momento.
+      </p>
+    ) : (
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {visible.map((p) => (
+          <article class="card bg-base-100 border border-base-200 hover:shadow-lg transition-shadow duration-200">
+            <figure class="h-40 bg-base-200 overflow-hidden flex items-center justify-center">
+              {p.data.image ? (
+                <Image
+                  src={p.data.image}
+                  alt={p.data.title}
+                  class="object-cover w-full h-full"
+                  loading="lazy"
+                  decoding="async"
+                />
+              ) : (
+                <div class="w-full h-full flex items-center justify-center text-base-content/40">
+                  Imagen no disponible
+                </div>
+              )}
+            </figure>
+            <div class="card-body p-4">
+              <h3 class="text-lg font-semibold mb-2">{p.data.title}</h3>
+              <p class="text-sm text-base-content/80 mb-3">
+                {p.data.description}
+              </p>
+
+              <div class="flex flex-wrap gap-2 mb-3">
+                {(p.data.tags ?? []).map((t: string) => (
+                  <span class="badge badge-outline text-xs">{t}</span>
+                ))}
+              </div>
+
+              <div class="flex items-center gap-3 mt-auto">
+                {p.data.github && (
+                  <a
+                    href={p.data.github}
+                    class="btn btn-ghost btn-sm"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Repositorio
+                  </a>
+                )}
+                {p.data.demo && (
+                  <a
+                    href={p.data.demo}
+                    class="btn btn-primary btn-sm text-white"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Ver demo
+                  </a>
+                )}
+              </div>
+            </div>
+          </article>
+        ))}
+      </div>
+    )
+  }
+</section>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -2,16 +2,17 @@ import { defineCollection, z } from "astro:content";
 
 const projects = defineCollection({
   type: "content",
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    publishDate: z.coerce.date(),
-    tags: z.array(z.string()),
-    image: z.string().optional(),
-    github: z.string().url().optional(),
-    demo: z.string().url().optional(),
-    draft: z.boolean().default(false),
-  }),
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      publishDate: z.coerce.date(),
+      tags: z.array(z.string()),
+      image: image().optional(),
+      github: z.string().url().optional(),
+      demo: z.string().url().optional(),
+      draft: z.boolean().default(false),
+    }),
 });
 
 export const collections = { projects };

--- a/src/content/projects/ejemplo-iot.mdx
+++ b/src/content/projects/ejemplo-iot.mdx
@@ -3,7 +3,6 @@ title: "Sistema de Control IT/OT Acuicultura"
 description: "Plataforma web para monitoreo y control de alimentadores automáticos usando Docker y MQTT."
 publishDate: "2024-03-11"
 tags: ["Docker", "MQTT", "Node.js", "Industrial"]
-image: "/assets/projects/iot-control.webp"
 github: "https://github.com/fgjcarlos/iot-control"
 draft: true
 ---
@@ -11,6 +10,8 @@ draft: true
 # Detalles del Proyecto
 
 Este es un ejemplo de cómo documentar tus proyectos IT/OT. Usar MDX te permite flexibilidad total.
+
+> **Nota:** Para añadir imagen, colocar el archivo en `src/content/projects/` y referenciar con ruta relativa en el frontmatter: `image: ./mi-imagen.webp`
 
 ### Desafíos Técnicos
 


### PR DESCRIPTION
Closes #24

## Summary

- Update `src/content/config.ts`: schema uses `image()` context helper (Astro v5 pattern) instead of `z.string()`, enabling the build-time optimization pipeline for project cover images
- Replace bare `<img>` in `Projects.astro` with `<Image />` from `astro:assets` with `loading="lazy"` and `decoding="async"`
- Remove invalid public-path string from draft example project; add inline note documenting the relative-path convention for future projects

## Changes

| File | Change |
|------|--------|
| `src/content/config.ts` | `image: z.string()` → `image: image().optional()` via schema context |
| `src/components/Projects.astro` | `<img>` → `<Image />` from `astro:assets` |
| `src/content/projects/ejemplo-iot.mdx` | Remove invalid `image` path, add usage note |

## Notes

- The `image()` helper in Astro v5 is provided via `SchemaContext`: `schema: ({ image }) => z.object({...})`
- For future projects: place images in `src/content/projects/` and reference with a relative path (e.g. `image: ./cover.webp`) — Astro will automatically optimize to WebP/AVIF

## Test Plan

- [x] `pnpm check` — 0 errors, 0 warnings, 0 hints
- [x] `pnpm format:check` — clean
- [x] `pnpm build` — complete