### PR TITLE
feat(ux): add ClientRouter for View Transitions

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,6 +4,7 @@ import Footer from "@components/Footer.astro";
 import "../styles/global.css";
 import "@fontsource/lxgw-wenkai-mono-tc";
 import SpeedInsights from "@vercel/speed-insights/astro";
+import { ClientRouter } from "astro:transitions";
 import profileData from "../config/profile.json";
 import linksData from "../config/links.json";
 
@@ -59,6 +60,9 @@ const jsonLd = {
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content={ogImage} />
+
+    <!-- View Transitions -->
+    <ClientRouter />
 
     <!-- JSON-LD Person schema -->
     <script


### PR DESCRIPTION
Closes #22

## Summary

Add `<ClientRouter />` from `astro:transitions` to `Layout.astro` `<head>`.
Enables SPA-like transitions between all routes with zero config.

## Notes

- Automatic `prefers-reduced-motion` support — no animations when user opts out
- DaisyUI dropdowns are unaffected (tested: no regressions)
- If individual elements need to persist across transitions, use `transition:persist`

## Changes

| File | Change |
|------|--------|
| `src/layouts/Layout.astro` | Import and render `<ClientRouter />` in `<head>` |

## Test Plan

- [x] `pnpm check` — 0 errors
- [x] `pnpm build` — complete
- [x] `pnpm format:check` — clean