### PR TITLE
perf(fonts): load latin + latin-ext subsets only (~200KB vs ~5MB)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,7 +2,8 @@
 import NavBar from "@components/NavBar.astro";
 import Footer from "@components/Footer.astro";
 import "../styles/global.css";
-import "@fontsource/lxgw-wenkai-mono-tc";
+import "@fontsource/lxgw-wenkai-mono-tc/latin-ext.css";
+import "@fontsource/lxgw-wenkai-mono-tc/latin.css";
 import SpeedInsights from "@vercel/speed-insights/astro";
 import profileData from "../config/profile.json";
 import linksData from "../config/links.json";


### PR DESCRIPTION
Closes #25

## Summary

Replace the bare `@fontsource/lxgw-wenkai-mono-tc` import (loads all subsets including ~4MB of chinese-traditional glyphs) with targeted subset imports.

## Changes

| File | Change |
|------|--------|
| `src/layouts/Layout.astro` | Replace `index` import with `latin.css` + `latin-ext.css` |

## Font payload

| Before | After |
|--------|-------|
| ~5MB (all subsets) | ~200KB (latin + latin-ext, 3 weights each) |

- `latin` — basic latin (20KB/weight × 3) — covers all ASCII characters
- `latin-ext` — extended latin for Spanish: é, ñ, ü, etc. (44–52KB/weight × 3)
- `font-display: swap` already set in `@fontsource` subset CSS — no FOIT

## Test Plan

- [x] `pnpm build` — `dist/_astro/` contains only latin/latin-ext woff2 files (~200KB total)
- [x] `pnpm check` — 0 errors
- [x] `pnpm format:check` — clean
- [x] Visual: font renders correctly for all Spanish characters