### PR TITLE
test(e2e): add Playwright smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,31 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 11.1.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E smoke tests
+        run: pnpm test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ docs/
 # Local Pi runtime state
 .atl/
 .pi/
+test-results/
+playwright-report/

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Smoke: Home page", () => {
+  test("has expected title", async ({ page }) => {
+    await page.goto("/");
+    await expect(page).toHaveTitle(/Carlos Fontán/);
+  });
+
+  test("profile image renders", async ({ page }) => {
+    await page.goto("/");
+    const img = page.locator('img[alt*="Carlos"]');
+    await expect(img).toBeVisible();
+    await expect(img).toHaveAttribute("src", /.+/);
+  });
+
+  test("social links have valid href and open in new tab", async ({ page }) => {
+    await page.goto("/");
+    const socialLinks = page.locator('a[target="_blank"][rel*="noopener"]');
+    const count = await socialLinks.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      const href = await socialLinks.nth(i).getAttribute("href");
+      expect(href).toBeTruthy();
+      expect(href).not.toBe("");
+    }
+  });
+
+  test("navbar anchor links are present", async ({ page }) => {
+    await page.goto("/");
+    const sobreMiLink = page.locator('a[href="#sobre-mi"]').first();
+    await expect(sobreMiLink).toBeVisible();
+  });
+
+  test("projects section renders without crashing", async ({ page }) => {
+    await page.goto("/");
+    // Section may be empty (all drafts) but must not throw
+    // Projects component is only shown if imported in index.astro
+    const body = await page.textContent("body");
+    expect(body).toBeTruthy();
+  });
+
+  test("404 page renders", async ({ page }) => {
+    const response = await page.goto("/pagina-que-no-existe");
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
     "check": "astro check",
+    "test:e2e": "playwright test",
     "astro": "astro"
   },
   "dependencies": {
@@ -29,6 +30,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^8.59.4",
     "@typescript-eslint/parser": "^8.56.1",
     "eslint": "^10.0.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:4321",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm build && pnpm preview",
+    url: "http://localhost:4321",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.2(jiti@2.4.2))
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.59.4
         version: 8.59.4(@typescript-eslint/parser@8.56.1(eslint@10.0.2(jiti@2.4.2))(typescript@5.9.3))(eslint@10.0.2(jiti@2.4.2))(typescript@5.9.3)
@@ -683,6 +686,11 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/pluginutils@5.2.0':
     resolution: {integrity: sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==}
@@ -1747,6 +1755,11 @@ packages:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2460,6 +2473,16 @@ packages:
 
   pkg-types@2.2.0:
     resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
@@ -3764,6 +3787,10 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@rollup/pluginutils@5.2.0(rollup@4.44.1)':
     dependencies:
       '@types/estree': 1.0.8
@@ -4967,6 +4994,9 @@ snapshots:
     dependencies:
       minipass: 3.3.6
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -5978,6 +6008,14 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-selector-parser@7.1.1:
     dependencies:


### PR DESCRIPTION
Closes #26

## Summary

Install `@playwright/test` and add 6 smoke assertions that protect against obvious regressions.

## Changes

| File | Change |
|------|--------|
| `e2e/smoke.spec.ts` | 6 smoke tests |
| `playwright.config.ts` | Config: Chromium, webServer, CI settings |
| `package.json` | Add `test:e2e` script |
| `.github/workflows/ci.yml` | Add `e2e` job (`needs: build`) |
| `.gitignore` | Ignore `test-results/`, `playwright-report/` |

## Tests

| Test | Assertion |
|------|-----------|
| Title | `/Carlos Fontán/` |
| Profile image | Visible, non-empty src |
| Social links | `href` non-empty, `target=_blank` |
| NavBar anchors | `#sobre-mi` link present |
| Body renders | Non-null body content |
| 404 page | HTTP 404 status |

## Test Plan

- [x] `pnpm check` — 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — clean
- [ ] `pnpm test:e2e` — runs against `astro preview` (requires Playwright browsers installed)