### PR TITLE
fix(ui): replace box-shadow with drop-shadow on profile photo

### DIFF
--- a/src/components/ProfileDescription.astro
+++ b/src/components/ProfileDescription.astro
@@ -12,13 +12,11 @@ const profile = Profile as ProfileConfig;
   id="sobre-mi"
   class="w-full flex flex-col md:flex-row-reverse gap-8 items-center justify-between mt-8 transition-all duration-700 animate-slide-up"
 >
-  <div
-    class="transform transition-all duration-500 hover:scale-110 hover:shadow-lg group"
-  >
+  <div class="group">
     <Image
       src={PhotoProfile}
       alt={profile.photoAlt}
-      class="mask mask-squircle size-32 sm:size-36 md:size-48 transition-all duration-300 group-hover:brightness-110"
+      class="mask mask-squircle size-32 sm:size-36 md:size-48 transition-all duration-500 hover:scale-110 hover:brightness-110 hover:drop-shadow-xl"
     />
   </div>
   <div class="flex flex-col items-center md:items-start md:flex-1">


### PR DESCRIPTION
## Problema

`hover:shadow-lg` en el div wrapper generaba sombra rectangular y esquinas blancas visibles al hacer hover, porque `mask-squircle` solo recorta el `<Image>`, no el div contenedor.

## Fix

Mover scale + sombra directamente al `<Image>` usando `filter: drop-shadow` (Tailwind: `hover:drop-shadow-xl`), que sigue la forma squircle en lugar de generar un box rectangular.

## Changes

| File | Change |
|------|--------|
| `src/components/ProfileDescription.astro` | Consolidar hover effects en `<Image>`, reemplazar `shadow-lg` por `drop-shadow-xl` |

## Test Plan

- [x] `pnpm build` — complete
- [x] `pnpm check` — 0 errors
- [x] `pnpm format:check` — clean