### PR TITLE
Portfolio improvements: perf, security, SEO, repo hygiene, a11y

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## What
+
+<!-- Concise description of the change. -->
+
+## Why
+
+<!-- Motivation: bug, feature request, performance, refactor, etc. -->
+
+## Test plan
+
+- [ ] `pnpm check` passes
+- [ ] `pnpm lint` passes
+- [ ] `pnpm format:check` passes
+- [ ] `pnpm build` succeeds
+- [ ] `pnpm test:e2e` passes (if UI/routes touched)
+- [ ] Verified locally in `pnpm dev` or `pnpm preview`
+
+## Notes
+
+<!-- Screenshots, follow-ups, related issues, breaking changes. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      astro:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "astro-*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "daisyui"
+      eslint:
+        patterns:
+          - "eslint"
+          - "@eslint/*"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+      types:
+        patterns:
+          - "@types/*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -p "require('./node_modules/@playwright/test/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cached browsers)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
 
       - name: Run E2E smoke tests
         run: pnpm test:e2e

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Carlos Fontán
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -11,9 +11,22 @@ import icon from 'astro-icon';
 export default defineConfig({
   site: 'https://fgjcarlos.com',
 
+  prefetch: {
+    prefetchAll: true,
+    defaultStrategy: 'viewport',
+  },
+
   vite: {
     plugins: [tailwindcss()]
   },
 
-  integrations: [mdx(), sitemap(), icon()]
+  integrations: [
+    mdx(),
+    sitemap({
+      changefreq: 'monthly',
+      priority: 0.7,
+      lastmod: new Date(),
+    }),
+    icon(),
+  ],
 });

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -1,0 +1,53 @@
+import { test } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+// TODO: switch this suite to assertive mode once existing
+// color-contrast violations on Layout/Footer are fixed.
+// Set A11Y_STRICT=1 in CI to fail on critical/serious violations.
+const STRICT = process.env.A11Y_STRICT === "1";
+
+const CRITICAL_IMPACTS = new Set(["critical", "serious"]);
+
+const pagesToScan = [
+  { name: "home", path: "/" },
+  { name: "project detail (mcm)", path: "/projects/mcm.mdx" },
+  { name: "404", path: "/pagina-que-no-existe" },
+];
+
+test.describe("a11y: WCAG 2 AA scan", () => {
+  for (const { name, path } of pagesToScan) {
+    test(`${name} — axe scan`, async ({ page }) => {
+      await page.goto(path);
+
+      const results = await new AxeBuilder({ page })
+        .withTags(["wcag2a", "wcag2aa"])
+        .analyze();
+
+      const blocking = results.violations.filter((v) =>
+        CRITICAL_IMPACTS.has(v.impact ?? ""),
+      );
+
+      if (blocking.length > 0) {
+        const summary = blocking.map((v) => ({
+          id: v.id,
+          impact: v.impact,
+          help: v.help,
+          nodes: v.nodes.length,
+          helpUrl: v.helpUrl,
+        }));
+        console.warn(`[a11y] ${name} has ${blocking.length} violation(s):`);
+        console.warn(JSON.stringify(summary, null, 2));
+        test.info().annotations.push({
+          type: "a11y-violations",
+          description: `${blocking.length} critical/serious violations on ${path}`,
+        });
+      }
+
+      if (STRICT && blocking.length > 0) {
+        throw new Error(
+          `[a11y strict] ${blocking.length} blocking violations on ${path}`,
+        );
+      }
+    });
+  }
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "@axe-core/playwright": "^4.11.3",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.60.0",
     "@typescript-eslint/eslint-plugin": "^8.59.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.6
         version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+      '@axe-core/playwright':
+        specifier: ^4.11.3
+        version: 4.11.3(playwright-core@1.60.0)
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.0.2(jiti@2.4.2))
@@ -134,6 +137,11 @@ packages:
 
   '@astrojs/yaml2ts@0.2.2':
     resolution: {integrity: sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==}
+
+  '@axe-core/playwright@4.11.3':
+    resolution: {integrity: sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -1218,6 +1226,10 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axe-core@4.11.4:
+    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+    engines: {node: '>=4'}
 
   axios@1.10.0:
     resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
@@ -3358,6 +3370,11 @@ snapshots:
     dependencies:
       yaml: 2.8.2
 
+  '@axe-core/playwright@4.11.3(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.11.4
+      playwright-core: 1.60.0
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.27.1': {}
@@ -4405,6 +4422,8 @@ snapshots:
       synckit: 0.11.12
 
   asynckit@0.4.0: {}
+
+  axe-core@4.11.4: {}
 
   axios@1.10.0:
     dependencies:

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -72,6 +72,9 @@ const jsonLd = {
       set:html={JSON.stringify(jsonLd)}
     />
 
+    <!-- Per-page head extensions (extra meta, JSON-LD, etc.) -->
+    <slot name="head" />
+
     <SpeedInsights />
     <title>{title}</title>
   </head>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -41,7 +41,7 @@ const jsonLd = {
 <html lang="es" data-theme="light">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -2,6 +2,7 @@
 import { getCollection, render } from "astro:content";
 import { Image } from "astro:assets";
 import Layout from "@layouts/Layout.astro";
+import profileData from "@config/profile.json";
 
 export async function getStaticPaths() {
   const projects = await getCollection("projects", ({ data }) => !data.draft);
@@ -21,9 +22,36 @@ const statusColors: Record<string, string> = {
   beta: "badge-info",
   stable: "badge-success",
 };
+
+const siteUrl = "https://fgjcarlos.com";
+const projectUrl = `${siteUrl}/projects/${project.id}`;
+
+const projectJsonLd: Record<string, unknown> = {
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  name: title,
+  description,
+  url: projectUrl,
+  dateCreated: publishDate.toISOString(),
+  keywords: tags.join(", "),
+  author: {
+    "@type": "Person",
+    name: profileData.name,
+    url: siteUrl,
+  },
+};
+
+if (github) projectJsonLd.codeRepository = github;
+if (demo) projectJsonLd.workExample = demo;
 ---
 
 <Layout title={`${title} — FGJCARLOS`} description={description}>
+  <script
+    slot="head"
+    type="application/ld+json"
+    is:inline
+    set:html={JSON.stringify(projectJsonLd)}
+  />
   <article class="w-full max-w-3xl mx-auto py-10 animate-slide-up">
     <!-- Back -->
     <a

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
         {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains; preload"
+        },
+        {
           "key": "Referrer-Policy",
           "value": "strict-origin-when-cross-origin"
         },


### PR DESCRIPTION
## What

Bundle de 10 mejoras enfocadas que tocan performance, seguridad, SEO, mantenimiento y testing. Cada item es un commit independiente y reviewable.

| # | Commit | Foco |
|---|--------|------|
| 1 | `fix(layout): add initial-scale=1 to viewport meta` | Mobile rendering correcto |
| 2 | `feat(security): add HSTS header` | Fuerza HTTPS en visitas posteriores |
| 3 | `perf(astro): enable viewport prefetch and configure sitemap options` | Prefetch nativo + sitemap con `lastmod`/`changefreq`/`priority` |
| 4 | `feat(layout): add named head slot for per-page metadata` | Permite que cada página inyecte tags en `<head>` |
| 5 | `feat(seo): emit JSON-LD CreativeWork for each project page` | Schema.org rico por proyecto (codeRepository, workExample, author) |
| 6 | `chore(ci): cache Playwright browsers across runs` | ~30-60s de ahorro por CI run cuando hay cache hit |
| 7 | `chore(repo): configure Dependabot for npm and github-actions` | Updates semanales agrupados (astro, tailwind, eslint, types) |
| 8 | `chore(repo): add pull request template` | Estandariza descripción de PRs futuros |
| 9 | `chore(repo): add MIT LICENSE` | El repo estaba sin licencia (= "all rights reserved" por defecto) |
| 10 | `test(a11y): add informational axe-core smoke test` | Scan WCAG 2 AA sobre home, project detail y 404 |

## Why

El portfolio venía con foco fuerte en performance/SEO/CI durante las últimas semanas. Estas mejoras cubren huecos puntuales detectados al revisar el repo:

- **Performance**: el prefetch de Astro combinado con `ClientRouter` deja las navegaciones instantáneas. Cachear los browsers de Playwright reduce el tiempo de CI considerablemente.
- **Seguridad**: HSTS faltaba en `vercel.json`. Sin él, un primer request HTTP teórico puede degradar.
- **SEO**: el JSON-LD `Person` ya estaba globalmente. Cada proyecto ahora emite además su `CreativeWork` schema con `codeRepository`, `workExample` y `dateCreated`. El sitemap recibe `changefreq`/`priority`/`lastmod` para mejor indexación.
- **Mantenimiento**: Dependabot agrupa updates por familia (astro, tailwind, eslint, types) para que las PRs semanales sean ruido mínimo. Template de PR fuerza estructura `What/Why/Test plan`. Licencia explícita.
- **Accesibilidad**: el test de axe es **informativo (no bloqueante)** porque encontró violaciones reales pre-existentes — color-contrast en varios elementos con `text-base-content/40-50`. Las muestra en logs como `[a11y]` y anota la run de Playwright. Para volverlo estricto: setear `A11Y_STRICT=1` (TODO documentado in-code).

## Deferred

- **CSP refinement**: `vercel.json` mantiene `'unsafe-inline'` en `script-src` por compatibilidad con JSON-LD inline + Speed Insights. Refactor con hashes SHA-256 o nonces va en PR separado — requiere decisiones más finas y testing en browser.
- **Color contrast violations**: las violaciones detectadas por axe necesitan revisión de los tokens de DaisyUI (`text-base-content/40`, `/50`). Es deuda de diseño, no scope de este PR.

## Test plan

- [x] `pnpm check` — 0 errors, 0 warnings, 0 hints
- [x] `pnpm lint` — limpio
- [x] `pnpm format:check` — limpio
- [x] `pnpm build` — 3 páginas generadas, sitemap emitido
- [x] `pnpm test:e2e` — 9/9 tests pasan (6 smoke + 3 a11y informativos)
- [x] JSON-LD por proyecto verificable inspeccionando `<head>` del build