### PR TITLE
fix(projects): install typography plugin and improve MDX prose styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@astrojs/sitemap": "^3.7.2",
     "@fontsource/lxgw-wenkai-mono-tc": "^5.2.7",
     "@iconify-json/arcticons": "^1.2.29",
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.11",
     "@vercel/speed-insights": "^1.2.0",
     "astro": "^6.3.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@iconify-json/arcticons':
         specifier: ^1.2.29
         version: 1.2.29
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.11)
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@7.3.3(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.9.0))
@@ -867,6 +870,11 @@ packages:
   '@tailwindcss/oxide@4.1.11':
     resolution: {integrity: sha512-Q69XzrtAhuyfHo+5/HMgr1lAiPP/G40OMFAnws7xcFEYqcypZmdW8eGXaOUIeOl1dzPJBPENXgbjsOyhg2nkrg==}
     engines: {node: '>= 10'}
+
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@tailwindcss/vite@4.1.11':
     resolution: {integrity: sha512-RHYhrR3hku0MJFRV+fN2gNbDNEh3dwKvY8XJvTxCSXeMOsCRSr+uKvDWQcbizrHgjML6ZmTE5OwMrl5wKcujCw==}
@@ -2365,6 +2373,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -3745,6 +3757,11 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.1.11
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.11
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.11
+
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.11)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.11
 
   '@tailwindcss/vite@4.1.11(vite@7.3.3(@types/node@24.12.4)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.9.0))':
     dependencies:
@@ -5734,6 +5751,11 @@ snapshots:
       playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@7.1.1:
     dependencies:

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -136,17 +136,23 @@ if (demo) projectJsonLd.workExample = demo;
 
     <!-- MDX body -->
     <div
-      class="prose prose-sm max-w-none
-      prose-headings:font-bold prose-headings:text-base-content
-      prose-h2:text-xl prose-h2:mt-10 prose-h2:mb-3
-      prose-h3:text-base prose-h3:mt-6 prose-h3:mb-2
-      prose-p:text-base-content/80 prose-p:leading-relaxed
-      prose-a:text-primary prose-a:underline-offset-4 hover:prose-a:text-primary/70
-      prose-code:text-sm prose-code:bg-base-200 prose-code:px-1 prose-code:rounded
-      prose-pre:bg-base-200 prose-pre:border prose-pre:border-base-300 prose-pre:rounded-box
-      prose-table:text-sm prose-th:text-left prose-td:align-top
-      prose-strong:text-base-content
-      prose-li:text-base-content/80"
+      class="prose prose-base max-w-none
+      prose-headings:font-bold prose-headings:text-base-content prose-headings:tracking-tight
+      prose-h2:text-2xl prose-h2:mt-12 prose-h2:mb-4 prose-h2:pb-2 prose-h2:border-b prose-h2:border-base-300
+      prose-h3:text-lg prose-h3:mt-8 prose-h3:mb-3
+      prose-p:text-base-content/80 prose-p:leading-relaxed prose-p:text-base
+      prose-a:text-primary prose-a:font-medium prose-a:underline prose-a:underline-offset-4 hover:prose-a:opacity-70
+      prose-strong:text-base-content prose-strong:font-semibold
+      prose-em:text-base-content/70
+      prose-code:text-sm prose-code:bg-base-200 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:font-medium prose-code:before:content-none prose-code:after:content-none
+      prose-pre:bg-base-200 prose-pre:border prose-pre:border-base-300 prose-pre:rounded-box prose-pre:text-sm
+      prose-blockquote:border-l-4 prose-blockquote:border-primary/30 prose-blockquote:bg-base-200/50 prose-blockquote:rounded-r-lg prose-blockquote:py-1
+      prose-ul:text-base-content/80 prose-ol:text-base-content/80
+      prose-li:text-base-content/80 prose-li:leading-relaxed
+      prose-table:text-sm prose-table:w-full
+      prose-thead:bg-base-200 prose-th:text-left prose-th:font-semibold prose-th:text-base-content prose-th:py-2 prose-th:px-3
+      prose-td:align-top prose-td:py-2 prose-td:px-3 prose-td:border-b prose-td:border-base-200
+      prose-hr:border-base-300"
     >
       <Content />
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @plugin "daisyui";
+@plugin "@tailwindcss/typography";
 
 @plugin "daisyui/theme" {
   name: "light";


### PR DESCRIPTION
Closes #48

## What

- Installs `@tailwindcss/typography` and registers it in `global.css`
- Scales prose wrapper from `prose-sm` to `prose-base`
- Adds visual hierarchy to H2/H3 headings, tables, inline code and blockquotes

## Why

`@tailwindcss/typography` was missing — all `prose-*` modifier classes in `[slug].astro` had zero effect. MDX content rendered as unstyled plain text: flat headings, unformatted tables, code without background.

## Test plan

- [x] `pnpm build` succeeds
- [x] Verified locally: heading hierarchy, table layout, code inline and blockquote styles render correctly on `/projects/nrcc`

## Notes

| File | Change |
|------|--------|
| `package.json` | Add `@tailwindcss/typography` dependency |
| `src/styles/global.css` | Register `@plugin "@tailwindcss/typography"` |
| `src/pages/projects/[slug].astro` | Upgrade prose classes for proper typography rendering |