### PR TITLE
fix: make mobile navbar menu accessible

### DIFF
--- a/e2e/mobile-nav.spec.ts
+++ b/e2e/mobile-nav.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Mobile navigation", () => {
+  test.use({ viewport: { width: 390, height: 844 }, isMobile: true });
+
+  test("hamburger button opens a visible, clickable section menu", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const menu = page.locator("nav .dropdown-content");
+    await expect(menu).toBeHidden();
+
+    await page
+      .getByRole("button", { name: "Abrir menú de navegación" })
+      .click();
+
+    await expect(menu).toBeVisible();
+
+    for (const label of ["Sobre mí", "Proyectos", "Contacto"]) {
+      await expect(menu.getByRole("link", { name: label })).toBeVisible();
+    }
+
+    await menu.getByRole("link", { name: "Proyectos" }).click();
+    await expect(page).toHaveURL(/#proyectos$/);
+  });
+
+  test("hamburger button exposes the menu to keyboard focus", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const menu = page.locator("nav .dropdown-content");
+    await page
+      .getByRole("button", { name: "Abrir menú de navegación" })
+      .focus();
+    await page.keyboard.press("Enter");
+
+    await expect(menu).toBeVisible();
+    await expect(menu.getByRole("link", { name: "Sobre mí" })).toBeVisible();
+  });
+});

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -35,18 +35,16 @@ const navLinks = [
   </ul>
 
   <!-- Mobile hamburger -->
-  <div class="md:hidden dropdown dropdown-end">
-    <label
-      tabindex="0"
+  <details class="md:hidden dropdown dropdown-end">
+    <summary
       role="button"
-      class="btn btn-ghost transition-all duration-300 hover:scale-110 hover:bg-base-300"
+      class="btn btn-ghost list-none transition-all duration-300 hover:scale-110 hover:bg-base-300"
       aria-label="Abrir menú de navegación"
     >
       <Icon name="arcticons:hamburger-menu" class="size-6" />
-    </label>
+    </summary>
     <ul
-      tabindex="0"
-      class="dropdown-content menu bg-base-100 rounded-box shadow-md w-48 mt-2 transition-all duration-300 opacity-0 invisible group-hover:opacity-100 group-hover:visible"
+      class="dropdown-content menu z-50 mt-2 w-48 rounded-box bg-base-100 shadow-md"
     >
       {
         navLinks.map((link) => (
@@ -61,5 +59,5 @@ const navLinks = [
         ))
       }
     </ul>
-  </div>
+  </details>
 </nav>


### PR DESCRIPTION
## Summary

Closes #53.

- Replaces the mobile navbar dropdown trigger with a native `<details>/<summary>` pattern so it opens deterministically on tap/click and keyboard activation.
- Removes the `opacity-0 invisible group-hover:*` classes that kept the mobile menu hidden.
- Adds Playwright mobile coverage for visible/clickable menu links and keyboard operation.

## Test Plan

- `pnpm exec playwright test e2e/mobile-nav.spec.ts --project=chromium`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test:e2e`

Notes: `astro check` still reports existing Zod deprecation hints in `src/content.config.ts`; e2e a11y tests still log existing color-contrast violations, but all tests pass.
