### PR TITLE
feat: smooth anchor section scrolling

### DIFF
--- a/e2e/anchor-scroll.spec.ts
+++ b/e2e/anchor-scroll.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+const anchorTargets = ["sobre-mi", "proyectos", "contacto"];
+
+test.describe("Anchor section navigation", () => {
+  test("uses smooth scrolling and reserves top offset for section anchors", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await expect(page.locator("html")).toHaveCSS("scroll-behavior", "smooth");
+
+    for (const id of anchorTargets) {
+      const target = page.locator(`#${id}`);
+      await expect(target).toHaveCount(1);
+      await expect(target).not.toHaveCSS("scroll-margin-top", "0px");
+    }
+  });
+
+  test("keeps anchor links navigable by hash", async ({ page }) => {
+    await page.goto("/");
+
+    for (const [label, hash] of [
+      ["Sobre mí", "#sobre-mi"],
+      ["Proyectos", "#proyectos"],
+      ["Contacto", "#contacto"],
+    ] as const) {
+      await page.getByRole("link", { name: label }).first().click();
+      await expect(page).toHaveURL(new RegExp(`${hash}$`));
+    }
+  });
+
+  test("disables smooth scrolling for reduced-motion users", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await page.goto("/");
+
+    await expect(page.locator("html")).toHaveCSS("scroll-behavior", "auto");
+  });
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,9 +41,33 @@
   --font-display: "LXGW WenKai Mono TC", monospace;
 }
 
+html {
+  scroll-behavior: smooth;
+  scroll-padding-top: 5rem;
+}
+
+[id] {
+  scroll-margin-top: 5rem;
+}
+
 *:focus-visible {
   outline: 2px solid oklch(77% 0.152 181.912);
   outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
 .bloque-con-margin {


### PR DESCRIPTION
## Summary

Closes #51.

- Adds global smooth scrolling for anchor navigation.
- Reserves top offset for anchored sections with `scroll-padding-top` and `scroll-margin-top`.
- Respects `prefers-reduced-motion: reduce` by disabling smooth scroll and minimizing transitions/animations.
- Adds Playwright coverage for anchor scroll CSS, hash navigation, and reduced-motion behavior.

## Test Plan

- `pnpm exec playwright test e2e/anchor-scroll.spec.ts --project=chromium`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test:e2e`

Notes: `astro check` still reports existing Zod deprecation hints in `src/content.config.ts`; e2e a11y tests still log existing color-contrast violations, but all tests pass.
