### PR TITLE
fix: stabilize project page transitions

### DIFF
--- a/e2e/page-transitions.spec.ts
+++ b/e2e/page-transitions.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Page transitions", () => {
+  test("keeps the shared shell stable when navigating between home and project detail", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const shell = page.locator("main");
+    const nav = page.locator("nav");
+    const beforeShellBox = await shell.boundingBox();
+    const beforeNavBox = await nav.boundingBox();
+
+    expect(beforeShellBox).not.toBeNull();
+    expect(beforeNavBox).not.toBeNull();
+
+    await page.locator('#proyectos a[href^="/projects/"]').first().click();
+    await page.waitForURL(/\/projects\//);
+
+    const afterShellBox = await shell.boundingBox();
+    const afterNavBox = await nav.boundingBox();
+
+    expect(afterShellBox).not.toBeNull();
+    expect(afterNavBox).not.toBeNull();
+    expect(afterShellBox?.x).toBeCloseTo(beforeShellBox!.x, 0);
+    expect(afterShellBox?.width).toBeCloseTo(beforeShellBox!.width, 0);
+    expect(afterNavBox?.y).toBeCloseTo(beforeNavBox!.y, 0);
+  });
+
+  test("does not replay transform-based entrance animations during client navigation", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.locator('#proyectos a[href^="/projects/"]').first().click();
+    await page.waitForURL(/\/projects\//);
+
+    const detailContent = page.locator("article").first();
+    await expect(detailContent).toBeVisible();
+    await expect(detailContent).toHaveCSS("animation-name", "none");
+    await expect(detailContent).toHaveCSS("transform", "none");
+  });
+
+  test("reserves a stable aspect ratio for project cover images", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.locator('#proyectos a[href^="/projects/"]').first().click();
+    await page.waitForURL(/\/projects\//);
+
+    const cover = page.locator("article > div.rounded-box").first();
+    await expect(cover).toBeVisible();
+    await expect(cover).not.toHaveCSS("aspect-ratio", "auto");
+  });
+});

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -80,6 +80,7 @@ const jsonLd = {
   </head>
   <body>
     <main
+      transition:animate="fade"
       class="container min-h-screen flex flex-col mx-auto max-w-7xl p-4 sm:p-6 md:p-8 lg:p-10 shadow-none sm:shadow-[4px_0_12px_-4px_rgba(0,0,0,0.08),-4px_0_12px_-4px_rgba(0,0,0,0.08)]"
     >
       <NavBar />

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -52,7 +52,11 @@ if (demo) projectJsonLd.workExample = demo;
     is:inline
     set:html={JSON.stringify(projectJsonLd)}
   />
-  <article class="w-full max-w-3xl mx-auto py-10 animate-slide-up">
+  <article
+    data-page-content
+    transition:animate="fade"
+    class="w-full max-w-3xl mx-auto py-10"
+  >
     <!-- Back -->
     <a
       href="/#proyectos"
@@ -122,11 +126,14 @@ if (demo) projectJsonLd.workExample = demo;
     <!-- Cover image -->
     {
       image && (
-        <div class="rounded-box overflow-hidden border border-base-200 mb-10 shadow-sm">
+        <div
+          data-project-cover
+          class="aspect-video rounded-box overflow-hidden border border-base-200 mb-10 shadow-sm bg-base-200"
+        >
           <Image
             src={image}
             alt={`Captura de ${title}`}
-            class="w-full object-cover"
+            class="w-full h-full object-cover"
             loading="eager"
             decoding="async"
           />


### PR DESCRIPTION
## Summary

Closes #52.

- Uses Astro's fade view transition on the shared page shell and project detail content.
- Removes the transform-based `animate-slide-up` entrance animation from project detail pages so it does not replay during client-side route changes.
- Reserves stable 16:9 space for project cover images with a neutral background before the image is decoded.
- Adds Playwright coverage for shared shell stability, no transform-based detail entrance animation, and stable project cover aspect ratio.

## Test Plan

- `pnpm exec playwright test e2e/page-transitions.spec.ts --project=chromium`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test:e2e`

Notes: `astro check` still reports existing Zod deprecation hints in `src/content.config.ts`; e2e a11y tests still log existing color-contrast violations, but all tests pass.
