### PR TITLE
fix: close mobile nav after section link click

### DIFF
--- a/e2e/mobile-nav.spec.ts
+++ b/e2e/mobile-nav.spec.ts
@@ -23,6 +23,8 @@ test.describe("Mobile navigation", () => {
 
     await menu.getByRole("link", { name: "Proyectos" }).click();
     await expect(page).toHaveURL(/#proyectos$/);
+    await expect(menu).toBeHidden();
+    await expect(page.locator("nav details")).not.toHaveAttribute("open", "");
   });
 
   test("hamburger button exposes the menu to keyboard focus", async ({

--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -35,7 +35,7 @@ const navLinks = [
   </ul>
 
   <!-- Mobile hamburger -->
-  <details class="md:hidden dropdown dropdown-end">
+  <details data-mobile-nav-menu class="md:hidden dropdown dropdown-end">
     <summary
       role="button"
       class="btn btn-ghost list-none transition-all duration-300 hover:scale-110 hover:bg-base-300"
@@ -61,3 +61,28 @@ const navLinks = [
     </ul>
   </details>
 </nav>
+
+<script>
+  const closeMobileNavOnLinkClick = () => {
+    const menu = document.querySelector("[data-mobile-nav-menu]");
+
+    if (
+      !(menu instanceof HTMLDetailsElement) ||
+      menu.dataset.closeHandlerAttached
+    ) {
+      return;
+    }
+
+    menu.dataset.closeHandlerAttached = "true";
+    menu.addEventListener("click", (event) => {
+      const target = event.target;
+
+      if (target instanceof Element && target.closest("a")) {
+        menu.open = false;
+      }
+    });
+  };
+
+  closeMobileNavOnLinkClick();
+  document.addEventListener("astro:page-load", closeMobileNavOnLinkClick);
+</script>


### PR DESCRIPTION
## Summary

- Closes the mobile `<details>` navbar menu after selecting any quick section link.
- Keeps the existing native details/summary menu behavior for tap/click and keyboard opening.
- Extends the mobile nav Playwright test so the regression is covered: selecting `Proyectos` must navigate to `#proyectos` and hide the menu.

## Test Plan

- `pnpm exec playwright test e2e/mobile-nav.spec.ts --project=chromium`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test:e2e`

Notes: `astro check` still reports existing Zod deprecation hints in `src/content.config.ts`; e2e a11y tests still log existing color-contrast violations, but all tests pass.
