### PR TITLE
feat: add ESP32-fg portfolio project

### DIFF
--- a/src/content/projects/esp32-fg.mdx
+++ b/src/content/projects/esp32-fg.mdx
@@ -1,0 +1,58 @@
+---
+title: "ESP32-fg — Smart Fish Farm Monitoring"
+description: "Educational IoT system for fish farm monitoring with ESP32-S3 and ESP32-C3 devices, ESP-NOW sensor nodes, MQTT integration and a React dashboard."
+publishDate: "2026-05-23"
+tags: ["C", "ESP-IDF", "ESP32", "ESP-NOW", "MQTT", "React"]
+github: "https://github.com/fgjcarlos/ESP32-fg"
+demo: "https://fgjcarlos.github.io/ESP32-fg/"
+status: "alpha"
+featured: false
+draft: false
+---
+
+## The problem
+
+Fish farm monitoring needs reliable environmental data at the edge: temperature, water quality, node health and actuator status. For a learning project, the challenge is building that full path without hiding the hard parts behind a black-box IoT platform.
+
+ESP32-fg turns that into a hands-on embedded systems roadmap: low-power sensor nodes, a gateway, wireless communication, MQTT integration and a web dashboard.
+
+## What it does
+
+**ESP32 gateway** — An ESP32-S3 gateway runs WiFi AP/STA, ESP-NOW, MQTT and a small embedded configuration panel for local operation.
+
+**Low-power sensor nodes** — ESP32-C3 nodes wake from deep sleep, read sensors, send compact ESP-NOW messages to the gateway and return to sleep to preserve battery life.
+
+**MQTT bridge** — The gateway forwards telemetry to a LAN/cloud MQTT broker, keeping the embedded network decoupled from the server and dashboard.
+
+**Full-stack learning path** — The repository includes tutorial material, phase-by-phase tasks, acceptance criteria and technical decision notes to document the learning process.
+
+## Stack
+
+| Layer         | Technology                                  |
+| ------------- | ------------------------------------------- |
+| Firmware      | C, ESP-IDF v5.x                             |
+| Wireless      | ESP-NOW, WiFi AP/STA                        |
+| Messaging     | MQTT                                        |
+| Backend       | Bun, TypeScript, SQLite                     |
+| Frontend      | Vite, React, Tailwind                       |
+| Documentation | Astro/Starlight-style GitHub Pages tutorial |
+
+## Architecture
+
+```text
+Server: MQTT + API + Dashboard
+        │
+       MQTT
+        │
+   ESP32-S3 Gateway
+        │
+     ESP-NOW
+        │
+ ESP32-C3 sensor nodes
+```
+
+The gateway owns the WiFi/ESP-NOW channel coordination and acts as the bridge between constrained battery-powered nodes and the rest of the system.
+
+## Current status
+
+Educational project in its initial planning and learning phase. The repository defines the architecture, phases and documentation structure before firmware and dashboard implementation are built out step by step.


### PR DESCRIPTION
## Summary
- Adds ESP32-fg as a visible portfolio project.
- Links the repository and GitHub Pages documentation/demo.
- Describes the ESP32-S3 gateway, ESP32-C3 sensor nodes, ESP-NOW/MQTT architecture and educational status.

## Test Plan
- [x] `pnpm run format:check`
- [x] `pnpm run check`
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm run test:e2e`

## Notes
- `astro check` still emits the existing `z` deprecation hints in `src/content.config.ts`.
- Existing a11y tests still log known color-contrast violations while passing.
